### PR TITLE
TagPro Analytics Collector compatibility with Single World Joiner

### DIFF
--- a/game/noScript/collector.js
+++ b/game/noScript/collector.js
@@ -209,12 +209,12 @@ tagpro.ready(function()
   else if(!witness)
   {
    witness = true;
-   if(location.port) // local game (port 8xxx)
+   if(location.port) // local game
    {
     server = location.hostname;
     port = parseInt(location.port, 10);
    }
-   else // single world joiner (port 9xxx)
+   else // single world joiner
    {
     var parts = tagproConfig.gameSocket.split(':');
     server = parts[0];

--- a/game/noScript/collector.js
+++ b/game/noScript/collector.js
@@ -209,8 +209,17 @@ tagpro.ready(function()
   else if(!witness)
   {
    witness = true;
-   server = location.hostname;
-   port = parseInt(location.port, 10);
+   if(location.port) // local game (port 8xxx)
+   {
+    server = location.hostname;
+    port = parseInt(location.port, 10);
+   }
+   else // single world joiner (port 9xxx)
+   {
+    var parts = tagproConfig.gameSocket.split(':');
+    server = parts[0];
+    port = parseInt(parts[1], 10);
+   }
    gameNow = dateNow;
    if(complete)
    {


### PR DESCRIPTION
Follow-up for https://github.com/Nick-Riggs/tagpro-addons/pull/13#issuecomment-433158498

@ylambda Please verify that the diff makes sense, including comments - I'm assuming SWJ in production will stay on 9xxx ports, with no port in address bar URL. (`location.port` converts to true if the address bar URL has a non-standard port, i.e. not 80 for HTTP or not 443 for HTTPS.)